### PR TITLE
fix unaccessible property

### DIFF
--- a/src/Constraint/Page.php
+++ b/src/Constraint/Page.php
@@ -6,7 +6,7 @@ use Codeception\Lib\Console\Message;
 class Page extends \PHPUnit\Framework\Constraint\Constraint
 {
     protected $uri;
-    private $string;
+    protected $string;
 
     public function __construct($string, $uri = '')
     {


### PR DESCRIPTION
                                                                         
  [yii\base\ErrorException] Undefined property: Codeception\PHPUnit\Constraint\WebDriver::$string  
                                                                                                   

Scenario Steps:

xpath occurence $I->see("some text","//table[@id='id']")

/www/vendor/codeception/phpunit-wrapper/src/Constraint/WebDriver.php:17
/www/vendor/phpunit/phpunit/src/Framework/Constraint/Constraint.php:54
/www/vendor/phpunit/phpunit/src/Framework/Assert.php:2209
/www/vendor/codeception/codeception/src/Codeception/Util/Shared/Asserts.php:289
/www/vendor/codeception/codeception/src/Codeception/Module/WebDriver.php:2858
/www/vendor/codeception/codeception/src/Codeception/Module/WebDriver.php:885
/www/vendor/codeception/codeception/src/Codeception/Step.php:263
/www/vendor/codeception/codeception/src/Codeception/Scenario.php:72